### PR TITLE
Add Prompt-Like Global-Tag for 2016H relvals (pro-tempore) and customize relval step accordingly

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -27,6 +27,8 @@ autoCond = {
     'run2_data'         :   '81X_dataRun2_v11',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
     'run2_data_relval'  :   '81X_dataRun2_relval_v14',
+    # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)  
+    'run2_data_promptlike' : '81X_dataRun2_PromptLike_v0',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '81X_dataRun2_HLT_frozen_v4',
     # GlobalTag for Run2 HLT: it points to the online GT

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -206,17 +206,17 @@ workflows[136.767] = ['',['RunZeroBias2016E','HLTDR2_2016','RECODR2_2016reHLT_HI
 workflows[136.768] = ['',['RunMuOnia2016E','HLTDR2_2016','RECODR2_2016reHLT_skimMuOnia_HIPM','HARVESTDR2']]
 
 ### run 2016H ###
-workflows[136.769] = ['',['RunHLTPhy2016H','HLTDR2_2016_Prompt','RECODR2_2016reHLT_HIPM_Prompt','HARVESTDR2']]
-workflows[136.770] = ['',['RunDoubleEG2016H','HLTDR2_2016_Prompt','RECODR2_2016reHLT_skimDoubleEG_HIPM_Prompt','HARVESTDR2']]
-workflows[136.771] = ['',['RunDoubleMuon2016H','HLTDR2_2016_Prompt','RECODR2_2016reHLT_HIPM_Prompt','HARVESTDR2']]
-workflows[136.772] = ['',['RunJetHT2016H','HLTDR2_2016_Prompt','RECODR2_2016reHLT_skimJetHT_HIPM_Prompt','HARVESTDR2']]
-workflows[136.773] = ['',['RunMET2016H','HLTDR2_2016_Prompt','RECODR2_2016reHLT_skimMET_HIPM_Prompt','HARVESTDR2']]
-workflows[136.774] = ['',['RunMuonEG2016H','HLTDR2_2016_Prompt','RECODR2_2016reHLT_skimMuonEG_HIPM_Prompt','HARVESTDR2']]
-workflows[136.775] = ['',['RunSingleEl2016H','HLTDR2_2016_Prompt','RECODR2_2016reHLT_HIPM_Prompt','HARVESTDR2']]
-workflows[136.776] = ['',['RunSingleMu2016H','HLTDR2_2016_Prompt','RECODR2_2016reHLT_HIPM_Prompt','HARVESTDR2']]
-workflows[136.777] = ['',['RunSinglePh2016H','HLTDR2_2016_Prompt','RECODR2_2016reHLT_skimSinglePh_HIPM_Prompt','HARVESTDR2']]
-workflows[136.778] = ['',['RunZeroBias2016H','HLTDR2_2016_Prompt','RECODR2_2016reHLT_HIPM_Prompt','HARVESTDR2']]
-workflows[136.779] = ['',['RunMuOnia2016H','HLTDR2_2016_Prompt','RECODR2_2016reHLT_skimMuOnia_HIPM_Prompt','HARVESTDR2']]
+workflows[136.769] = ['',['RunHLTPhy2016H','HLTDR2_2016','RECODR2_2016reHLT_HIPM_Prompt','HARVESTDR2']]
+workflows[136.770] = ['',['RunDoubleEG2016H','HLTDR2_2016','RECODR2_2016reHLT_skimDoubleEG_HIPM_Prompt','HARVESTDR2']]
+workflows[136.771] = ['',['RunDoubleMuon2016H','HLTDR2_2016','RECODR2_2016reHLT_HIPM_Prompt','HARVESTDR2']]
+workflows[136.772] = ['',['RunJetHT2016H','HLTDR2_2016','RECODR2_2016reHLT_skimJetHT_HIPM_Prompt','HARVESTDR2']]
+workflows[136.773] = ['',['RunMET2016H','HLTDR2_2016','RECODR2_2016reHLT_skimMET_HIPM_Prompt','HARVESTDR2']]
+workflows[136.774] = ['',['RunMuonEG2016H','HLTDR2_2016','RECODR2_2016reHLT_skimMuonEG_HIPM_Prompt','HARVESTDR2']]
+workflows[136.775] = ['',['RunSingleEl2016H','HLTDR2_2016','RECODR2_2016reHLT_HIPM_Prompt','HARVESTDR2']]
+workflows[136.776] = ['',['RunSingleMu2016H','HLTDR2_2016','RECODR2_2016reHLT_HIPM_Prompt','HARVESTDR2']]
+workflows[136.777] = ['',['RunSinglePh2016H','HLTDR2_2016','RECODR2_2016reHLT_skimSinglePh_HIPM_Prompt','HARVESTDR2']]
+workflows[136.778] = ['',['RunZeroBias2016H','HLTDR2_2016','RECODR2_2016reHLT_HIPM_Prompt','HARVESTDR2']]
+workflows[136.779] = ['',['RunMuOnia2016H','HLTDR2_2016','RECODR2_2016reHLT_skimMuOnia_HIPM_Prompt','HARVESTDR2']]
 
 
 ### fastsim ###

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1095,9 +1095,6 @@ menuR2_2016 = autoHLT[hltKey2016]
 steps['HLTDR2_2016']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2016,},{'--conditions':'auto:run2_hlt_relval'},{'--era' : 'Run2_2016'},steps['HLTD'] ] )
 steps['HLTDR2newL1repack_2016']=merge( [ {'-s':'L1REPACK:FullSimTP,HLT:@%s'%hltKey2016,},{'--conditions':'auto:run2_hlt_relval'},{'--era' : 'Run2_2016'},steps['HLTD'] ] )
 
-# HLT step with Prompt-like GT 
-steps['HLTDR2_2016_Prompt']=merge( [ {'--conditions':'auto:run2_hlt_relval'},steps['HLTDR2_2016'] ] )
-
 # use --era 
 steps['RECODR2_50ns']=merge([{'--scenario':'pp','--conditions':'auto:run2_data_relval','--era':'Run2_50ns',},dataReco])
 steps['RECODR2_25ns']=merge([{'--scenario':'pp','--conditions':'auto:run2_data_relval','--era':'Run2_25ns','--customise':'Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_25ns'},dataReco])
@@ -1271,14 +1268,14 @@ for sname in ['RECODR2_50nsreHLT', 'RECODR2_25nsreHLT',
 
 
 # RECO step with Prompt-like GT
-steps['RECODR2_2016reHLT_HIPM_Prompt']=merge([{'--conditions':'auto:run2_data_relval'},steps['RECODR2_2016reHLT_HIPM']])
-steps['RECODR2_2016reHLT_skimDoubleEG_HIPM_Prompt']=merge([{'--conditions':'auto:run2_data_relval'},steps['RECODR2_2016reHLT_skimDoubleEG_HIPM']])
-steps['RECODR2_2016reHLT_skimJetHT_HIPM_Prompt']=merge([{'--conditions':'auto:run2_data_relval'},steps['RECODR2_2016reHLT_skimJetHT_HIPM']])
-steps['RECODR2_2016reHLT_skimMET_HIPM_Prompt']=merge([{'--conditions':'auto:run2_data_relval'},steps['RECODR2_2016reHLT_skimMET_HIPM']])
-steps['RECODR2_2016reHLT_skimMuonEG_HIPM_Prompt']=merge([{'--conditions':'auto:run2_data_relval'},steps['RECODR2_2016reHLT_skimMuonEG_HIPM']])
-steps['RECODR2_2016reHLT_skimSingleMu_HIPM_Prompt']=merge([{'--conditions':'auto:run2_data_relval'},steps['RECODR2_2016reHLT_skimSingleMu_HIPM']])
-steps['RECODR2_2016reHLT_skimSinglePh_HIPM_Prompt']=merge([{'--conditions':'auto:run2_data_relval'},steps['RECODR2_2016reHLT_skimSinglePh_HIPM']])
-steps['RECODR2_2016reHLT_skimMuOnia_HIPM_Prompt']=merge([{'--conditions':'auto:run2_data_relval'},steps['RECODR2_2016reHLT_skimMuOnia_HIPM']])
+steps['RECODR2_2016reHLT_HIPM_Prompt']=merge([{'--conditions':'auto:run2_data_promptlike'},steps['RECODR2_2016reHLT_HIPM']])
+steps['RECODR2_2016reHLT_skimDoubleEG_HIPM_Prompt']=merge([{'--conditions':'auto:run2_data_promptlike'},steps['RECODR2_2016reHLT_skimDoubleEG_HIPM']])
+steps['RECODR2_2016reHLT_skimJetHT_HIPM_Prompt']=merge([{'--conditions':'auto:run2_data_promptlike'},steps['RECODR2_2016reHLT_skimJetHT_HIPM']])
+steps['RECODR2_2016reHLT_skimMET_HIPM_Prompt']=merge([{'--conditions':'auto:run2_data_promptlike'},steps['RECODR2_2016reHLT_skimMET_HIPM']])
+steps['RECODR2_2016reHLT_skimMuonEG_HIPM_Prompt']=merge([{'--conditions':'auto:run2_data_promptlike'},steps['RECODR2_2016reHLT_skimMuonEG_HIPM']])
+steps['RECODR2_2016reHLT_skimSingleMu_HIPM_Prompt']=merge([{'--conditions':'auto:run2_data_promptlike'},steps['RECODR2_2016reHLT_skimSingleMu_HIPM']])
+steps['RECODR2_2016reHLT_skimSinglePh_HIPM_Prompt']=merge([{'--conditions':'auto:run2_data_promptlike'},steps['RECODR2_2016reHLT_skimSinglePh_HIPM']])
+steps['RECODR2_2016reHLT_skimMuOnia_HIPM_Prompt']=merge([{'--conditions':'auto:run2_data_promptlike'},steps['RECODR2_2016reHLT_skimMuOnia_HIPM']])
 
 
 steps['RECO']=merge([step3Defaults])


### PR DESCRIPTION
Hi @fabozzi 
In short:

- 1) there is no need to customize the HLT GlobalTag, the one in autoCond is just as good as it will ever be
- 2) I 've added a new key for Prompt-Like conditions (adapted to run in 81x), and explicitly customizing the L1 menu to be compatible with what is run in the HLT@relval2016 step.

@franzoni @arunhep you might want to watch this. 
